### PR TITLE
Fixes typo in …/editor/TmarColorSettingsPage.kt

### DIFF
--- a/plugin/src/main/kotlin/io/nimbly/tzatziki/editor/TmarColorSettingsPage.kt
+++ b/plugin/src/main/kotlin/io/nimbly/tzatziki/editor/TmarColorSettingsPage.kt
@@ -68,7 +68,7 @@ class TzColorSettingsPage : ColorSettingsPage {
 
     override fun getAttributeDescriptors()
         = listOf(AttributesDescriptor("Test passed", TEST_OK),
-                AttributesDescriptor("Test deffect", TEST_KO),
+                AttributesDescriptor("Test defect", TEST_KO),
                 AttributesDescriptor("Test ignored", TEST_IGNORED),
                 AttributesDescriptor("Step is deprecated", DEPRECATED)).toTypedArray()
 


### PR DESCRIPTION
Fixed a typo in the ColorSettingsPage.

Note: If you need the PR in another form, for example for a branch (that is not main) please let me know.
Doing my best to help. 🙂

Signed-off-by: Stephan Kämper <the.tester@seasidetesting.com>