### PR TITLE
fix: compatibility with 2025.1 EAP

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import java.net.URI
 
 allprojects {
     group = "io.nimbly.tzatziki"
-    version = "17.10.0"
+    version = "17.11.0"
 }
 
 val notes by extra {"""

--- a/plugin-i18n/build.gradle.kts
+++ b/plugin-i18n/build.gradle.kts
@@ -56,7 +56,7 @@ tasks {
 
         // Check build number here : https://www.jetbrains.com/idea/download/other.html
         sinceBuild.set("222.4554.10")    // 2021.2.4
-        untilBuild.set("243.*")
+        untilBuild.set("251.*")
 
         changeNotes.set(notes)
     }

--- a/plugin-tzatziki/build.gradle.kts
+++ b/plugin-tzatziki/build.gradle.kts
@@ -62,7 +62,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("222")    // 2021.2.4
-        untilBuild.set("243.*")
+        untilBuild.set("251.*")
 
         changeNotes.set(notes)
     }


### PR DESCRIPTION
Seemingly, there are no breaking changes on the build 2025.1 EAP, bumping the `until version` seems sufficient.