### PR TITLE
Fix: running a single Scenario Outline example

### DIFF
--- a/extensions/java-cucumber/src/main/kotlin/io/nimbly/tzatziki/TzCucumberJavaRunConfigurationProducer.kt
+++ b/extensions/java-cucumber/src/main/kotlin/io/nimbly/tzatziki/TzCucumberJavaRunConfigurationProducer.kt
@@ -27,13 +27,11 @@ import io.nimbly.tzatziki.psi.table
 import io.nimbly.tzatziki.util.ellipsis
 import io.nimbly.tzatziki.util.findPreviousSiblingsOfType
 import io.nimbly.tzatziki.util.parentOfTypeIs
-import org.jetbrains.plugins.cucumber.java.run.CucumberJavaFeatureRunConfigurationProducer
 import org.jetbrains.plugins.cucumber.java.run.CucumberJavaRunConfiguration
+import org.jetbrains.plugins.cucumber.java.run.CucumberJavaScenarioRunConfigurationProducer
 import org.jetbrains.plugins.cucumber.psi.*
 
-// CucumberJavaScenarioRunConfigurationProducer was removed in cucumber-java 252.25557.23+
-// CucumberJavaFeatureRunConfigurationProducer is its direct parent and still present
-class TzCucumberJavaRunConfigurationProducer : CucumberJavaFeatureRunConfigurationProducer() {
+class TzCucumberJavaRunConfigurationProducer : CucumberJavaScenarioRunConfigurationProducer() {
 
     override fun setupConfigurationFromContext(
         configuration: CucumberJavaRunConfiguration,


### PR DESCRIPTION
Fixes #120

### Root cause

Commit `1c81c79` ("Fix #118", shipped in 18.6.1) changed the parent class of `TzCucumberJavaRunConfigurationProducer` from `CucumberJavaScenarioRunConfigurationProducer` to `CucumberJavaFeatureRunConfigurationProducer`, with a comment claiming the Scenario producer was removed in `cucumber-java` 252+.

That assumption is wrong. In `cucumber-java` 253.30387.20 the Scenario producer is still present and still registered. Worse, `CucumberJavaFeatureRunConfigurationProducer.getFileToRun()` returns `null` when the click is inside a `GherkinScenario` / `GherkinScenarioOutline`, so `super.setupConfigurationFromContext(...)` leaves `configuration.filePath` as `null` and our override returns `false`.

IntelliJ then falls back to the bundled `CucumberJavaScenarioRunConfigurationProducer`, which only sets a name-filter regex matching every expanded example, with no `:line` constraint — so Cucumber runs all examples of the outline.

### Fix

Restore `CucumberJavaScenarioRunConfigurationProducer` as the parent class. With it, `super` correctly sets `filePath` and `nameFilter`, and our existing override appends `:<exampleLine>` so Cucumber runs only the clicked example. Pre-18.6.1 behavior restored.

Verified on IntelliJ IDEA Ultimate 2026.1.1, Cucumber for Java 261.x, Cucumber 7.34.3, Java 25.

### Diff

One file, imports + base class only:

```diff
-import org.jetbrains.plugins.cucumber.java.run.CucumberJavaFeatureRunConfigurationProducer
 import org.jetbrains.plugins.cucumber.java.run.CucumberJavaRunConfiguration
+import org.jetbrains.plugins.cucumber.java.run.CucumberJavaScenarioRunConfigurationProducer

-class TzCucumberJavaRunConfigurationProducer : CucumberJavaFeatureRunConfigurationProducer() {
+class TzCucumberJavaRunConfigurationProducer : CucumberJavaScenarioRunConfigurationProducer() {
```

---
*Disclosure: This PR was prepared with the assistance of AI (GitHub Copilot). All changes were reviewed and tested by me.*