### PR TITLE
Add basic Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: build
+
+build:
+	./gradlew --no-daemon plugin-tzatziki:buildPlugin


### PR DESCRIPTION
### basic `Makefile`

a simple `make` for building the plugin for newcomers to the project so they don't have to sift through `./gradlew tasks` in order to figure out what to do; in fact I am not even 100% sure this is correct - should it be `./gradlew build` or maybe `./gradlew assemble`? Is `build` doing too much like running tests and pulling extra test dependencies?

btw, this also serves as a sort of ~spec for LLMs to quickly figure out some basic commands